### PR TITLE
Add version

### DIFF
--- a/example.py
+++ b/example.py
@@ -19,7 +19,7 @@ async def main():
         data = Hole("192.168.0.215", loop, session)
 
         await data.get_versions()
-        print(json.dumps(data.data, indent=4, sort_keys=True))
+        print(json.dumps(data.versions, indent=4, sort_keys=True))
 
         await data.get_data()
 

--- a/hole/__init__.py
+++ b/hole/__init__.py
@@ -35,6 +35,7 @@ class Hole(object):
         self.location = location
         self.api_token = api_token
         self.data = {}
+        self.versions = {}
         self.base_url = _INSTANCE.format(
             schema=self.schema, host=self.host, location=self.location
         )
@@ -62,8 +63,8 @@ class Hole(object):
                 response = await self._session.get(self.base_url, params=params)
 
             _LOGGER.info("Response from *hole: %s", response.status)
-            self.data = await response.json()
-            _LOGGER.debug(self.data)
+            self.versions = await response.json()
+            _LOGGER.debug(self.versions)
 
         except (asyncio.TimeoutError, aiohttp.ClientError, socket.gaierror):
             msg = "Can not load data from *hole: {}".format(self.host)


### PR DESCRIPTION
It does not really make sense that both get_versions() and get_data() uses the same dict.
Most of the other functions expects the self.data dict to be filled by get_data(), not get_versions().

This will also make it easier to create sensors for versions and possible version upgrades and "upgrade is available" in HA.