### PR TITLE
Don't depend on async-timeout for Python 3.11+.

### DIFF
--- a/hole/v5.py
+++ b/hole/v5.py
@@ -5,7 +5,12 @@ import logging
 import socket
 
 import aiohttp
-import async_timeout
+import sys
+
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+else:
+    import async_timeout
 
 from . import exceptions
 

--- a/hole/v6.py
+++ b/hole/v6.py
@@ -8,7 +8,12 @@ import logging
 from typing import Optional, Literal
 
 import aiohttp
-import async_timeout
+import sys
+
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+else:
+    import async_timeout
 
 from . import exceptions
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license="MIT",
     install_requires=[
         "aiohttp<4",
-        "async_timeout>4,<5",
+        'async_timeout; python_version < "3.11"',
     ],
     packages=["hole"],
     python_requires=">=3.9",


### PR DESCRIPTION
This library was upstreamed into the standard library and is thus deprecated.